### PR TITLE
🧾 Προσθήκη υποστήριξης custom format view για Bridge.Status αντικείμενα

### DIFF
--- a/BridgeWatcher/BridgeWatcher.psd1
+++ b/BridgeWatcher/BridgeWatcher.psd1
@@ -1,17 +1,18 @@
 @{
-    RootModule = 'BridgeWatcher.psm1'
-    ModuleVersion = '1.0.34'
-    GUID = 'e7c0fd85-a740-47f4-8179-d952e33edb9f'
-    Author = 'Γιάννης Καπλατζής'
-    CompanyName = 'Open Source Community'
-    Copyright = '(c) 2025 Γιάννης Καπλατζής. MIT License.'
-    Description = 'Παρακολούθηση κατάστασης γεφυρών Ισθμίας & Ποσειδωνίας, με υποστήριξη OCR και ειδοποιήσεις Pushover.'
-    PowerShellVersion = '5.1'
-    RequiredModules      = @()
-    RequiredAssemblies   = @()
-    CmdletsToExport      = @()
-    VariablesToExport    = @()
-    AliasesToExport      = @()
+    RootModule            = 'BridgeWatcher.psm1'
+    ModuleVersion         = '1.0.34'
+    GUID                  = 'e7c0fd85-a740-47f4-8179-d952e33edb9f'
+    Author                = 'Γιάννης Καπλατζής'
+    CompanyName           = 'Open Source Community'
+    Copyright             = '(c) 2025 Γιάννης Καπλατζής. MIT License.'
+    Description           = 'Παρακολούθηση κατάστασης γεφυρών Ισθμίας & Ποσειδωνίας, με υποστήριξη OCR και ειδοποιήσεις Pushover.'
+    PowerShellVersion     = '5.1'
+    RequiredModules       = @()
+    RequiredAssemblies    = @()
+    CmdletsToExport       = @()
+    VariablesToExport     = @()
+    AliasesToExport       = @()
+    FormatsToProcess     = @('Formats/BridgeStatus.format.ps1xml')
     FunctionsToExport = @(
         'Get-BridgeStatus',
         'Get-BridgePreviousStatus',

--- a/BridgeWatcher/BridgeWatcher.psd1
+++ b/BridgeWatcher/BridgeWatcher.psd1
@@ -12,8 +12,8 @@
     CmdletsToExport       = @()
     VariablesToExport     = @()
     AliasesToExport       = @()
-    FormatsToProcess     = @('Formats/BridgeStatus.format.ps1xml')
-    FunctionsToExport = @(
+    FormatsToProcess      = @('Formats/BridgeStatus.format.ps1xml')
+    FunctionsToExport     = @(
         'Get-BridgeStatus',
         'Get-BridgePreviousStatus',
         'Get-BridgeStatusComparison',
@@ -21,28 +21,12 @@
         'Send-BridgePushover',
         'Start-BridgeStatusMonitor'
     )
-    PrivateData = @{
+    PrivateData        = @{
         PSData = @{
-            Tags       = @('Bridge', 'Monitoring', 'Pushover', 'OCR')
-            LicenseUri = 'https://opensource.org/licenses/MIT'
-            ProjectUri = 'https://github.com/mrjcap/BridgeWatcher'
-            ReleaseNotes = 'Πρώτη επίσημη έκδοση.'
+            Tags            = @('Bridge', 'Monitoring', 'Pushover', 'OCR')
+            LicenseUri      = 'https://opensource.org/licenses/MIT'
+            ProjectUri      = 'https://github.com/mrjcap/BridgeWatcher'
+            ReleaseNotes    = 'Πρώτη επίσημη έκδοση.'
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/BridgeWatcher/Formats/BridgeStatus.format.ps1xml
+++ b/BridgeWatcher/Formats/BridgeStatus.format.ps1xml
@@ -1,0 +1,45 @@
+<?xml version    = "1.0" encoding    = "utf-8"?>
+<Configuration>
+    <ViewDefinitions>
+    <View>
+        <Name>BridgeStatusView</Name>
+        <ViewSelectedBy>
+        <TypeName>Bridge.Status</TypeName>
+        </ViewSelectedBy>
+        <TableControl>
+        <AutoSize />
+        <TableHeaders>
+            <TableColumnHeader>
+            <Label>GefyraName</Label>
+            <Width>16</Width>
+            </TableColumnHeader>
+            <TableColumnHeader>
+            <Label>GefyraStatus</Label>
+            <Width>12</Width>
+            </TableColumnHeader>
+            <TableColumnHeader>
+            <Label>Timestamp</Label>
+            <Width>18</Width>
+            </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+            <TableRowEntry>
+            <TableColumnItems>
+                <TableColumnItem>
+                <PropertyName>GefyraName</PropertyName>
+                </TableColumnItem>
+                <TableColumnItem>
+                <PropertyName>GefyraStatus</PropertyName>
+                </TableColumnItem>
+                <TableColumnItem>
+                <ScriptBlock>
+                    [DateTime]::Parse($_.Timestamp).ToString('yyyy-MM-dd HH:mm')
+                </ScriptBlock>
+                </TableColumnItem>
+            </TableColumnItems>
+            </TableRowEntry>
+        </TableRowEntries>
+        </TableControl>
+    </View>
+    </ViewDefinitions>
+</Configuration>

--- a/BridgeWatcher/Private/New-BridgeStatusObject.ps1
+++ b/BridgeWatcher/Private/New-BridgeStatusObject.ps1
@@ -42,6 +42,7 @@
         [Parameter()][string]$BaseUrl = 'https://www.topvision.gr/dioriga/'
     )
     return [pscustomobject]@{
+        PSTypeName   = 'Bridge.Status'
         GefyraName   = if ($Location -eq 'poseidonia') { 'Ποσειδωνία' } else { 'Ισθμία' }
         GefyraStatus = $Status
         Timestamp    = $Timestamp


### PR DESCRIPTION

- Δημιουργήθηκε το αρχείο `BridgeStatus.format.ps1xml` με custom πίνακα για τα πεδία GefyraName, GefyraStatus και Timestamp (μορφοποιημένο)
- Ορίστηκε `PSTypeName = 'Bridge.Status'` στο output της `New-BridgeStatusObject` για ενεργοποίηση format view
- Ενημερώθηκε το `BridgeWatcher.psd1` με `FormatsToProcess = @('Formats/BridgeStatus.format.ps1xml')` για σωστό import του format

🧹 Cleanup: Ευθυγράμμιση πεδίων στο module manifest για αναγνωσιμότητα
- Ενοποιήθηκε το indentation για όλα τα πεδία του `BridgeWatcher.psd1`
- Δεν αλλάζει καμία λειτουργικότητα – purely cosmetic αλλαγή